### PR TITLE
Remove manually added plugin from CorePlugins in .abignore.

### DIFF
--- a/Insomnia/.abproject
+++ b/Insomnia/.abproject
@@ -22,7 +22,6 @@
   "ProjectTypeGuids": "{070BCB52-5A75-4F8C-A973-144AF0EAFCC9}",
   "FrameworkVersion": "3.5.0",
   "CorePlugins": [
-    "nl.x-services.plugins.insomnia",
     "org.apache.cordova.console",
     "org.apache.cordova.device",
     "org.apache.cordova.device-orientation",


### PR DESCRIPTION
In order to build and deploy an app with manually added plugin to Plugins folder you don't need it in the .abproject file otherwise the error below is thrown:

Error: ENOENT, stat '/Users/builder/BpcTooling/Cordova3/3.5.0/CorePlugins/nl.x-services.plugins.insomnia'

/Users/builder/BpcTooling/Cordova3/node_modules/cordova-build-utils/bin/install-plugins-3.js:166
                        throw Error("exit code: " + code);
                              ^
Error: exit code: 1
    at Error (<anonymous>)
    at ChildProcess.<anonymous> (/Users/builder/BpcTooling/Cordova3/node_modules/cordova-build-utils/bin/install-plugins-3.js:166:13)
    at ChildProcess.emit (events.js:98:17)
    at Process.ChildProcess._handle.onexit (child_process.js:809:12)

Done building project "Insomnia.tmp.proj" -- FAILED.
